### PR TITLE
Trivial ghc-7.6 update

### DIFF
--- a/Data/MemoCombinators.hs
+++ b/Data/MemoCombinators.hs
@@ -115,7 +115,7 @@ integral :: (Integral a) => Memo a
 integral = wrap fromInteger toInteger bits
 
 -- | Memoize an ordered type with a bits instance.
-bits :: (Ord a, Bits a) => Memo a
+bits :: (Ord a, Num a, Bits a) => Memo a
 bits f = IntTrie.apply (fmap f IntTrie.identity)
 
 -- | @switch p a b@ uses the memo table a whenever p gives


### PR DESCRIPTION
This and the data-inttrie patch take account of the weaker Bits class in more  recent base. The errors in data-intrie mostly come from numeric literals so they could be handled in other ways e.g. by wrapping the literals in 'bit 0', 'bit 1' etc.   http://stackoverflow.com/questions/12560619/bits-is-not-derived-from-num
