### PR TITLE
Make it buildable with ghc-7.6

### DIFF
--- a/Data/MemoCombinators.hs
+++ b/Data/MemoCombinators.hs
@@ -115,7 +115,7 @@ integral :: (Integral a) => Memo a
 integral = wrap fromInteger toInteger bits
 
 -- | Memoize an ordered type with a bits instance.
-bits :: (Ord a, Bits a) => Memo a
+bits :: (Num a, Ord a, Bits a) => Memo a
 bits f = IntTrie.apply (fmap f IntTrie.identity)
 
 -- | @switch p a b@ uses the memo table a whenever p gives


### PR DESCRIPTION
Maybe it will be helpful to fix that error message when I get when trying to build data-memocombinators with ghc-7.6.1:

```
Data/MemoCombinators.hs:119:10:
    Could not deduce (Num a) arising from a use of `IntTrie.apply'
    from the context (Ord a, Bits a)
      bound by the type signature for bits :: (Ord a, Bits a) => Memo a
      at Data/MemoCombinators.hs:118:9-33
    Possible fix:
      add (Num a) to the context of
        the type signature for bits :: (a -> r) -> a -> r
        or the type signature for bits :: (Ord a, Bits a) => Memo a
    In the expression: IntTrie.apply (fmap f IntTrie.identity)
    In an equation for `bits':
        bits f = IntTrie.apply (fmap f IntTrie.identity)
cabal: Error: some packages failed to install:
data-memocombinators-0.4.3 failed during the building phase. The exception
was:
ExitFailure 1
```
